### PR TITLE
minor improvements

### DIFF
--- a/wheel-metadata-injector/examples/README.md
+++ b/wheel-metadata-injector/examples/README.md
@@ -4,7 +4,15 @@ This directory contains an example of how to use the wheel-metadata-injector as 
 
 ## Using the Plugin
 
-1. First, install wheel-metadata-injector:
+1. Add `wheel-metadata-injector` to `build-system.requires`, for example, using `setuptools`:
+
+```toml
+[build-system]
+requires = ["setuptools", "wheel-metadata-injector"]
+build-backend = "setuptools.build_meta"
+```
+
+Alternatively, it can be manually installed:
 
 ```bash
 pip install wheel-metadata-injector
@@ -50,10 +58,10 @@ setup(
 
 ## Building a Wheel
 
-After setting up your setup.py, build your wheel as usual:
+After setting up your setup.py, build your wheel, e.g. using [`build`](https://pypi.org/project/build/)  (`pip install build`)
 
 ```bash
-python setup.py bdist_wheel
+python -m build
 ```
 
 The plugin will automatically inject the environment metadata into the wheel after it's built.

--- a/wheel-metadata-injector/examples/pyproject.toml
+++ b/wheel-metadata-injector/examples/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["setuptools", "wheel-metadata-injector"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "example-package"
+version = "0.1.0"
+description = "Example package leveraging wheel-metadata-injector"
+requires-python = ">=3.8"

--- a/wheel-metadata-injector/examples/setup.py
+++ b/wheel-metadata-injector/examples/setup.py
@@ -7,7 +7,6 @@ setup(
     name="example-package",
     version="0.1.0",
     packages=find_packages(),
-    python_requires=">=3.8",
     cmdclass={
         "bdist_wheel": InjectMetadataBdistWheel,
     },

--- a/wheel-metadata-injector/python/wheel_metadata_injector/setuptools_plugin.py
+++ b/wheel-metadata-injector/python/wheel_metadata_injector/setuptools_plugin.py
@@ -99,7 +99,7 @@ class InjectMetadataBdistWheel(bdist_wheel):
                 elif self.env_file:
                     process_wheel_with_env_file(wheel_path, self.env_file, None)
                 else:
-                    process_wheel(wheel_path)
+                    process_wheel(wheel_path, None)
                 print(f"Successfully injected environment metadata into {wheel_path}")
             except Exception as e:
                 print(f"Error injecting environment metadata: {e}")


### PR DESCRIPTION
- example: add pyproject.toml
- setuptool_plugin: use correct process_wheel arguments when no env vars are detected
