### PR TITLE
add git repo warning for isolated builds

### DIFF
--- a/wheel-metadata-injector/src/lib.rs
+++ b/wheel-metadata-injector/src/lib.rs
@@ -195,7 +195,12 @@ pub fn get_repository_info() -> Option<RepositoryInfo> {
     // Get git information from the current directory using libgit2
     let repo = match git2::Repository::discover(".") {
         Ok(repo) => repo,
-        Err(_) => return None,
+        Err(_) => {
+            println!(
+                "wheel-metadata-injector couldn not find git repo, is this an isolated build?"
+            );
+            return None;
+        }
     };
 
     let remotes = match repo.remotes() {

--- a/wheel-metadata-injector/src/lib.rs
+++ b/wheel-metadata-injector/src/lib.rs
@@ -197,7 +197,7 @@ pub fn get_repository_info() -> Option<RepositoryInfo> {
         Ok(repo) => repo,
         Err(_) => {
             println!(
-                "wheel-metadata-injector couldn not find git repo, is this an isolated build?"
+                "WARNING: wheel-metadata-injector could not find git repo, is this an isolated build?"
             );
             return None;
         }


### PR DESCRIPTION
add warning when no git repos can be discovered, this is the case when doing isolated builds (e.g. `python -m build`)
